### PR TITLE
Add back cca-pls-toolkit@cs.ucl.ac.uk in README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Our detailed documentation can be found [here](https://MLNL.github.io/cca_pls_to
 
 Some of the code used in the toolkit was developed by [Joao Monteiro](https://github.com/jmmonteiro) who was a PhD student at UCL (currently a data scientist at Heni). We wish to thank members and collaborators of the [Machine Learning & Neuroimaging Laboratory](http://www.mlnl.cs.ucl.ac.uk) for testing the toolkit and providing invaluable feedback. We would particularly like to acknowledge Eliana Nicolaisen, Cemre Zor, Konstantinos Tsirlis, Taiane Ramos and Richard Nguyen.
 
+Feel free to report any bugs under [cca-pls-toolkit@cs.ucl.ac.uk](mailto:cca-pls-toolkit@cs.ucl.ac.uk) or by creating an issue [here](https://github.com/anaston/cca_pls_toolkit/issues). Pull requests are also welcome to [https://github.com/anaston/cca_pls_toolkit](https://github.com/anaston/cca_pls_toolkit), however, unfortunately we don't have the resources to provide general user support.
+
 ## Acknowledgements
 
 The CCA/PLS toolkit was developed at the [__Machine Learning & Neuroimaging Laboratory (MLNL)__](http://www.mlnl.cs.ucl.ac.uk), Centre for Medical Imaging Computing, Computer Science Department, University College London, UK. The development of the toolkit was supported by the Wellcome Trust (grant number WT102845/Z/13/Z).

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -34,6 +34,8 @@ Please use the menu on the left to get started with the toolkit.
 
 Some of the code used in the toolkit was developed by [Joao Monteiro](https://github.com/jmmonteiro) who was a PhD student at UCL (currently a data scientist at Heni). We wish to thank members and collaborators of the [Machine Learning & Neuroimaging Laboratory](http://www.mlnl.cs.ucl.ac.uk) for testing the toolkit and providing invaluable feedback. We would particularly like to acknowledge Eliana Nicolaisen, Cemre Zor, Konstantinos Tsirlis, Taiane Ramos and Richard Nguyen.
 
+Feel free to report any bugs under [cca-pls-toolkit@cs.ucl.ac.uk](mailto:cca-pls-toolkit@cs.ucl.ac.uk) or by creating an issue [here](https://github.com/anaston/cca_pls_toolkit/issues). Pull requests are also welcome to [https://github.com/anaston/cca_pls_toolkit](https://github.com/anaston/cca_pls_toolkit), however, unfortunately we don't have the resources to provide general user support.
+
 ## Acknowledgements
 
 The CCA/PLS toolkit was developed at the [__Machine Learning & Neuroimaging Laboratory (MLNL)__](http://www.mlnl.cs.ucl.ac.uk), Centre for Medical Imaging Computing, Computer Science Department, University College London, UK. The development of the toolkit was supported by the Wellcome Trust (grant number WT102845/Z/13/Z).


### PR DESCRIPTION
Provide clarification for the email to be used only for reporting bugs.